### PR TITLE
Updating a bunch of things

### DIFF
--- a/data/books.json
+++ b/data/books.json
@@ -128,7 +128,7 @@
 			},
 			{
 				"url": "https://www.thebookpatch.com/BookStore/my-little-dashie/9da85c66-b5a3-4186-9cf1-88f349068ce3",
-				"title": "Perfect-Bound Paperback"
+				"title": "Paperback"
 			}
 		],
 		"tags": [
@@ -155,7 +155,7 @@
 				"title": "Fimfiction.net"
 			},{
 				"url": "https://www.lulu.com/shop/xupla-mindblower/the-story-of-my-life/paperback/product-20404756.html",
-				"title": "Perfect-Bound Paperback"
+				"title": "Paperback"
 			}
 		],
 		"tags": [
@@ -191,7 +191,7 @@
 			},
 			{
 				"url": "https://www.lulu.com/shop/tyler-barton/the-stranger-and-her-friend/paperback/product-21422895.html",
-				"title": "Perfect-Bound Paperback"
+				"title": "Paperback"
 			}
 		],
 		"tags": [
@@ -219,7 +219,7 @@
 			},
 			{
 				"url": "https://www.lulu.com/shop/tyler-weiss/the-tale-of-saving-grace/paperback/product-21251555.html",
-				"title": "Perfect-Bound Paperback"
+				"title": "Paperback"
 			}
 		],
 		"tags": [
@@ -230,7 +230,7 @@
 		"id": 9,
 		"title": "The Hope Called Night: Firstborn",
 		"edition": "?",
-		"img": "https://static.lulu.com/browse/product_thumbnail.php?productId=21584438&resolution=320",
+		"img": "https://assets.lulu.com/cover_thumbs/1/p/1penvpk5-front-shortedge-384.jpg",
 		"rating": "?",
 		"dateAdded": "2018/12/29",
 		"expiry": null,
@@ -254,7 +254,7 @@
 		"id": 11,
 		"title": "Daring Do Adventures #1: Daring Do and the Quest for the Sapphire Stone",
 		"edition": "?",
-		"img": "https://static.lulu.com/browse/product_thumbnail.php?productId=22624966&resolution=320",
+		"img": "https://assets.lulu.com/cover_thumbs/1/p/1pynvk2g-front-shortedge-384.jpg",
 		"rating": "E",
 		"dateAdded": "2018/12/29",
 		"expiry": null,
@@ -327,7 +327,7 @@
 			},
 			{
 				"url": "https://www.lulu.com/shop/geodesicdragon/of-horses-and-whorses/paperback/product-22839346.html",
-				"title": "Perfect-Bound Paperback"
+				"title": "Paperback"
 			}
 		],
 		"tags": [
@@ -341,7 +341,7 @@
 		"img": "https://cdn-img.fimfiction.net/story/pzq1-1432512521-141549-medium",
 		"rating": "T",
 		"dateAdded": "2018/12/29",
-		"expiry": null,
+		"expiry": "2020/11/18",
 		"authors":[
 			{
 				"name": "iisaw",
@@ -373,7 +373,7 @@
 		"img": "https://cdn-img.fimfiction.net/story/5ver-1432555680-175385-medium",
 		"rating": "T",
 		"dateAdded": "2018/12/29",
-		"expiry": null,
+		"expiry": "2020/11/18",
 		"authors":[
 			{
 				"name": "iisaw",
@@ -405,7 +405,7 @@
 		"img": "https://cdn-img.fimfiction.net/story/ckwi-1432614757-264005-medium",
 		"rating": "T",
 		"dateAdded": "2018/12/29",
-		"expiry": null,
+		"expiry": "2020/11/18",
 		"authors":[
 			{
 				"name": "iisaw",
@@ -451,7 +451,7 @@
 			},
 			{
 				"url": "https://www.amazon.com/Change-Life-Bernard-Doove/dp/149482177X/",
-				"title": "Perfect-Bound Paperback"
+				"title": "Paperback"
 			}
 		],
 		"tags": [
@@ -479,7 +479,7 @@
 			},
 			{
 				"url": "https://www.amazon.com/Growing-Up-Dandy-Bernard-Doove/dp/1499388470/",
-				"title": "Perfect-Bound Paperback"
+				"title": "Paperback"
 			}
 		],
 		"tags": [
@@ -507,7 +507,7 @@
 			},
 			{
 				"url": "https://www.amazon.com/Conversations-In-A-Canterlot-Cafe/dp/1505411041/",
-				"title": "Perfect-Bound Paperback"
+				"title": "Paperback"
 			}
 		],
 		"tags": [
@@ -535,7 +535,7 @@
 			},
 			{
 				"url": "https://www.amazon.com/Different-Perspective-Bernard-Doove/dp/1519185537/",
-				"title": "Perfect-Bound Paperback"
+				"title": "Paperback"
 			}
 		],
 		"tags": [
@@ -563,7 +563,7 @@
 			},
 			{
 				"url": "https://www.amazon.com/Growing-Years-Bernard-Doove/dp/1532898851/",
-				"title": "Perfect-Bound Paperback"
+				"title": "Paperback"
 			}
 		],
 		"tags": [
@@ -691,7 +691,7 @@
 			},
 			{
 				"url": "https://www.thebookpatch.com/BookStore/past-sins/35b50398-956a-4890-8868-21ef8f58d904",
-				"title": "Perfect-Bound Paperback"
+				"title": "Paperback"
 			}
 		],
 		"tags": [
@@ -702,7 +702,7 @@
 		"id": 27,
 		"title": "Torchwood: The New Equestria Files",
 		"edition": "?",
-		"img": "https://static.lulu.com/browse/product_thumbnail.php?productId=16532790&resolution=320",
+		"img": "https://assets.lulu.com/cover_thumbs/1/9/19q4n98e-front-shortedge-384.jpg",
 		"rating": "M",
 		"dateAdded": "2018/12/29",
 		"expiry": null,
@@ -719,7 +719,7 @@
 			},
 			{
 				"url": "https://www.lulu.com/shop/jonathan-lopez/torchwood-the-new-equestria-files/paperback/product-16532790.html",
-				"title": "Perfect-Bound Paperback"
+				"title": "Paperback"
 			}
 		],
 		"tags": [
@@ -747,7 +747,7 @@
 			},
 			{
 				"url": "https://www.lulu.com/shop/aurora-dawn/therainbowfactory/paperback/product-21796634.html",
-				"title": "Perfect-Bound Paperback"
+				"title": "Paperback"
 			}
 		],
 		"tags": [
@@ -775,7 +775,7 @@
 			},
 			{
 				"url": "https://www.lulu.com/shop/arby-works-and-ezrienel/hail-mary/paperback/product-21378699.html",
-				"title": "Perfect-Bound Paperback"
+				"title": "Paperback"
 			}
 		],
 		"tags": [
@@ -797,7 +797,7 @@
 			},
 			{
 				"name": "Ashton Crimson",
-				"url": "http://www.lulu.com/shop/search.ep?contributorId=1452280"
+				"url": "https://www.lulu.com/search?contributor=Ashton+Crimson"
 			}
 		],
 		"links": [
@@ -807,11 +807,11 @@
 			},
 			{
 				"url": "https://www.lulu.com/shop/ashton-crimson/the-lost-element-vol-1-a-newcomer-in-equestria-part-1/paperback/product-22857031.html",
-				"title": "Perfect-Bound Paperback (Part 1)"
+				"title": "Paperback (Part 1)"
 			},
 			{
 				"url": "https://www.lulu.com/shop/ashton-crimson/the-lost-element-vol-1-a-newcomer-in-equestria-part-2/paperback/product-22857036.html",
-				"title": "Perfect-Bound Paperback (Part 2)"
+				"title": "Paperback (Part 2)"
 			}
 		],
 		"tags": [
@@ -918,8 +918,8 @@
 		],
 		"links": [
 			{
-				"url": "http://broniesforgood.org/bound-together/",
-				"title": "Perfect-Bound Paperback"
+				"url": "https://broniesforgood.org/bound-together/",
+				"title": "Paperback"
 			}
 		],
 		"tags": [
@@ -930,7 +930,7 @@
 		"id": 33,
 		"title": "Book of Gaia: EQUESTRIA, Volume 1",
 		"edition": "?",
-		"img": "http://bookshow.blurb.com/bookshow/cache/P10411283/md/cover_2.jpeg?access_key=acd0fbe68a29ea7815af9e0575dabb3b",
+		"img": "https://bookshow.blurb.com/bookshow/cache/P10411283/md/cover_2.jpeg?access_key=acd0fbe68a29ea7815af9e0575dabb3b",
 		"rating": "E",
 		"dateAdded": "2018/12/30",
 		"expiry": null,
@@ -942,8 +942,8 @@
 		],
 		"links": [
 			{
-				"url": "http://www.blurb.com/bookstore/invited/5774309/c9e396a7a185ec31d3f6328cf3a7dc54a33f79e1",
-				"title": "Perfect-Bound Paperback"
+				"url": "https://www.blurb.com/bookstore/invited/5774309/c9e396a7a185ec31d3f6328cf3a7dc54a33f79e1",
+				"title": "Paperback"
 			}
 		],
 		"tags": [
@@ -957,7 +957,7 @@
 		"img": "https://static.lulu.com/browse/product_thumbnail.php?productId=21038899&resolution=320",
 		"rating": "E",
 		"dateAdded": "2018/12/30",
-		"expiry": null,
+		"expiry": "2020/11/01",
 		"authors":[
 			{
 				"name": "Thomas Taylor",
@@ -967,7 +967,7 @@
 		"links": [
 			{
 				"url": "https://www.lulu.com/shop/thomas-taylor/my-little-pony/paperback/product-21038899.html",
-				"title": "Perfect-Bound Paperback"
+				"title": "Paperback"
 			}
 		],
 		"tags": [
@@ -978,7 +978,7 @@
 		"id": 35,
 		"title": "Rainbow Light and Friends: A Coloring Book",
 		"edition": "?",
-		"img": "https://static.lulu.com/browse/product_thumbnail.php?productId=20596075&resolution=320",
+		"img": "https://assets.lulu.com/cover_thumbs/1/p/1peg625k-front-shortedge-384.jpg",
 		"rating": "E",
 		"dateAdded": "2018/12/30",
 		"expiry": null,
@@ -991,7 +991,7 @@
 		"links": [
 			{
 				"url": "https://www.lulu.com/shop/sarah-sellers/rainbow-light-and-friends-a-coloring-book/paperback/product-20596075.html",
-				"title": "Perfect-Bound Paperback"
+				"title": "Paperback"
 			}
 		],
 		"tags": [
@@ -1002,7 +1002,7 @@
 		"id": 36,
 		"title": "Mlp Comic",
 		"edition": "?",
-		"img": "https://static.lulu.com/browse/product_thumbnail.php?productId=21267574&resolution=320",
+		"img": "https://assets.lulu.com/cover_thumbs/1/9/19zjyz79-front-shortedge-384.jpg",
 		"rating": "E",
 		"dateAdded": "2018/12/30",
 		"expiry": null,
@@ -1026,7 +1026,7 @@
 		"id": 37,
 		"title": "Equestria",
 		"edition": "1st",
-		"img": "https://static.lulu.com/browse/product_thumbnail.php?productId=22147894&resolution=320",
+		"img": "https://assets.lulu.com/cover_thumbs/1/g/1g8jk278-front-shortedge-384.jpg",
 		"rating": "E",
 		"dateAdded": "2018/12/30",
 		"expiry": null,
@@ -1039,7 +1039,7 @@
 		"links": [
 			{
 				"url": "https://www.lulu.com/shop/ryan-compton/equestria/paperback/product-22147894.html",
-				"title": "Perfect-Bound Paperback"
+				"title": "Paperback"
 			}
 		],
 		"tags": [
@@ -1053,7 +1053,7 @@
 		"img": "https://static.lulu.com/browse/product_thumbnail.php?productId=22759210&resolution=320",
 		"rating": "E",
 		"dateAdded": "2018/12/30",
-		"expiry": null,
+		"expiry": "2020/11/01",
 		"authors":[
 			{
 				"name": "(Various)",
@@ -1074,7 +1074,7 @@
 		"id": 82,
 		"title": "Brony: The Unexpected Adult Fandom of \"My Little Pony, Friendship is Magic\"",
 		"edition": "1st",
-		"img": "http://bookshow.blurb.com/bookshow/cache/P6776240/md/cover_2.jpeg?access_key=ff14ccf932326520756ff32db2f8d6a2",
+		"img": "https://bookshow.blurb.com/bookshow/cache/P6776240/md/cover_2.jpeg?access_key=ff14ccf932326520756ff32db2f8d6a2",
 		"rating": "E",
 		"dateAdded": "2018/12/30",
 		"expiry": null,
@@ -1086,15 +1086,15 @@
 		],
 		"links": [
 			{
-				"url": "http://www.blurb.com/b/4234406-brony-the-unexpected-adult-fandom-of-my-little-pon",
-				"title": "Perfect-Bound Paperback"
+				"url": "https://www.blurb.com/b/4234406-brony-the-unexpected-adult-fandom-of-my-little-pon",
+				"title": "Paperback"
 			},
 			{
-				"url": "http://www.blurb.com/b/4234406-brony-the-unexpected-adult-fandom-of-my-little-pon",
+				"url": "https://www.blurb.com/b/4234406-brony-the-unexpected-adult-fandom-of-my-little-pon",
 				"title": "Hardcover"
 			},
 			{
-				"url": "http://www.blurb.com/b/4234406-brony-the-unexpected-adult-fandom-of-my-little-pon",
+				"url": "https://www.blurb.com/b/4234406-brony-the-unexpected-adult-fandom-of-my-little-pon",
 				"title": "Hardcover with Dust Cover"
 			}
 		],
@@ -1109,7 +1109,7 @@
 		"img": "https://static.lulu.com/browse/product_thumbnail.php?productId=21954294&resolution=320",
 		"rating": "M",
 		"dateAdded": "2018/12/30",
-		"expiry": null,
+		"expiry": "2020/11/01",
 		"authors":[
 			{
 				"name": "Iris Trismegistus",
@@ -1132,7 +1132,7 @@
 		"edition": "?",
 		"img": "https://static.lulu.com/browse/product_thumbnail.php?productId=21954275&resolution=320",
 		"rating": "M",
-		"dateAdded": "2018/12/30",
+		"dateAdded": "2020/11/01",
 		"expiry": null,
 		"authors":[
 			{
@@ -1154,7 +1154,7 @@
 		"id": 41,
 		"title": "My Little Sweetheart",
 		"edition": "?",
-		"img": "https://static.lulu.com/browse/product_thumbnail.php?productId=21966176&resolution=320",
+		"img": "https://assets.lulu.com/cover_thumbs/1/r/1re549w4-front-shortedge-384.jpg",
 		"rating": "M",
 		"dateAdded": "2018/12/30",
 		"expiry": null,
@@ -1167,7 +1167,7 @@
 		"links": [
 			{
 				"url": "https://www.lulu.com/shop/iris-trismegistus/my-little-sweetheart/paperback/product-21966176.html",
-				"title": "Perfect-Bound Paperback"
+				"title": "Paperback"
 			}
 		],
 		"tags": [
@@ -1178,7 +1178,7 @@
 		"id": 42,
 		"title": "My Little Sweetheart Too!",
 		"edition": "?",
-		"img": "https://static.lulu.com/browse/product_thumbnail.php?productId=21966290&resolution=320",
+		"img": "https://assets.lulu.com/cover_thumbs/1/4/14m7dpyw-front-shortedge-384.jpg",
 		"rating": "M",
 		"dateAdded": "2018/12/30",
 		"expiry": null,
@@ -1191,7 +1191,7 @@
 		"links": [
 			{
 				"url": "https://www.lulu.com/shop/iris-trismegistus/my-little-sweetheart-too/paperback/product-21966290.html",
-				"title": "Perfect-Bound Paperback"
+				"title": "Paperback"
 			}
 		],
 		"tags": [
@@ -1202,7 +1202,7 @@
 		"id": 43,
 		"title": "My Little Sweetheart 3",
 		"edition": "?",
-		"img": "https://static.lulu.com/browse/product_thumbnail.php?productId=21774461&resolution=320",
+		"img": "https://assets.lulu.com/cover_thumbs/1/j/1jn789r2-front-shortedge-384.jpg",
 		"rating": "M",
 		"dateAdded": "2018/12/30",
 		"expiry": null,
@@ -1215,7 +1215,7 @@
 		"links": [
 			{
 				"url": "https://www.lulu.com/shop/iris-trismegistus/my-little-sweetheart-3/paperback/product-21774461.html",
-				"title": "Perfect-Bound Paperback"
+				"title": "Paperback"
 			}
 		],
 		"tags": [
@@ -1226,7 +1226,7 @@
 		"id": 44,
 		"title": "My Little Sweetheart 4",
 		"edition": "?",
-		"img": "https://static.lulu.com/browse/product_thumbnail.php?productId=21928579&resolution=320",
+		"img": "https://assets.lulu.com/cover_thumbs/1/7/179pvqnk-front-shortedge-384.jpg",
 		"rating": "M",
 		"dateAdded": "2018/12/30",
 		"expiry": null,
@@ -1239,7 +1239,7 @@
 		"links": [
 			{
 				"url": "https://www.lulu.com/shop/iris-trismegistus/my-little-sweetheart-4/paperback/product-21928579.html",
-				"title": "Perfect-Bound Paperback"
+				"title": "Paperback"
 			}
 		],
 		"tags": [
@@ -1250,7 +1250,7 @@
 		"id": 45,
 		"title": "My Little Sweetheart 5",
 		"edition": "?",
-		"img": "https://static.lulu.com/browse/product_thumbnail.php?productId=22565505&resolution=320",
+		"img": "https://assets.lulu.com/cover_thumbs/1/v/1v4wmd5k-front-shortedge-384.jpg",
 		"rating": "M",
 		"dateAdded": "2018/12/30",
 		"expiry": null,
@@ -1263,7 +1263,7 @@
 		"links": [
 			{
 				"url": "https://www.lulu.com/shop/iris-trismegistus/my-little-sweetheart-5/paperback/product-22565505.html",
-				"title": "Perfect-Bound Paperback"
+				"title": "Paperback"
 			}
 		],
 		"tags": [
@@ -1287,7 +1287,7 @@
 		"links": [
 			{
 				"url": "https://braeburned.bigcartel.com/product/all-aboard",
-				"title": "Signed Perfect-Bound Paperback"
+				"title": "Signed Paperback"
 			}
 		],
 		"tags": [
@@ -1296,8 +1296,8 @@
 	}
 	,{
 		"id": 47,
-		"title": "Fallout: Equestria",
-		"edition": "4th",
+		"title": "Fallout: Equestria (AE)",
+		"edition": "4",
 		"img": "https://cdn-img.fimfiction.net/story/fuca-1432496101-119190-medium",
 		"rating": "M",
 		"dateAdded": "2018/12/30",
@@ -1779,7 +1779,7 @@
 			},
 			{
 				"url": "https://www.lulu.com/shop/erik-loyd/reflections/paperback/product-23935297.html",
-				"title": "Perfect-Bound Paperback"
+				"title": "Paperback"
 			},
 			{
 				"url": "https://www.dropbox.com/s/fmpy55j2y9gp3zs/Reflections.pdf?dl=1",
@@ -1881,7 +1881,7 @@
 		"img": "https://cdn-img.fimfiction.net/story/v7qy-1484156641-360348-medium",
 		"rating": "T",
 		"dateAdded": "2019/01/03",
-		"expiry": null,
+		"expiry": "2020/11/18",
 		"authors":[
 			{
 				"name": "iisaw",
@@ -1959,7 +1959,7 @@
 			},
 			{
 				"url": "https://www.lulu.com/shop/erik-loyd/feedback/paperback/product-23884649.html",
-				"title": "Perfect-bound Paperback"
+				"title": "Paperback"
 			}
 		],
 		"tags": [
@@ -1991,7 +1991,7 @@
 			},
 			{
 				"url": "https://www.lulu.com/shop/erik-loyd/substitute/paperback/product-23868667.html",
-				"title": "Perfect-bound Paperback"
+				"title": "Paperback"
 			}
 		],
 		"tags": [
@@ -2023,7 +2023,7 @@
 			},
 			{
 				"url": "",
-				"title": "Perfect-bound Paperback"
+				"title": "Paperback"
 			}
 		],
 		"tags": [
@@ -2118,11 +2118,11 @@
 				"title": "Audiobook"
 			},
 			{
-				"url": "http://www.lulu.com/shop/krickis/looking-glass/hardcover/product-23909632.html",
+				"url": "https://www.lulu.com/shop/krickis/looking-glass/hardcover/product-23909632.html",
 				"title": "Hardcover with Dust Cover (Color)"
 			},
 			{
-				"url": "http://www.lulu.com/shop/krickis/looking-glass/hardcover/product-23909647.html",
+				"url": "https://www.lulu.com/shop/krickis/looking-glass/hardcover/product-23909647.html",
 				"title": "Hardcover with Dust Cover (B&W)"
 			}
 		],
@@ -2162,7 +2162,7 @@
 		"id": 74,
 		"title": "Background Pony",
 		"edition": "1st",
-		"img": "https://cdn-img.fimfiction.net/story/zhml-1432427782-19198-medium",
+		"img": "https://cdn-img.fimfiction.net/story/dv8q-1585877781-19198-medium",
 		"rating": "T",
 		"dateAdded": "2019/01/06",
 		"expiry": null,
@@ -2297,7 +2297,7 @@
 		"img": "https://cdn-img.fimfiction.net/story/0xm9-1441146045-208056-medium",
 		"rating": "M",
 		"dateAdded": "2019/01/29",
-		"expiry": "2019/04/01",
+		"expiry": null,
 		"authors":[
 			{
 				"name": "Somber",
@@ -2320,6 +2320,14 @@
 			{
 				"url": "https://www.ministryofimage.net/product-page/fallout-equestria-project-horizons-part-3",
 				"title": "Hardcover (Volume 3)"
+			},
+			{
+				"url": "https://www.ministryofimage.net/product-page/fallout-equestria-project-horizons-part-4",
+				"title": "Hardcover (Volume 4)"
+			},
+			{
+				"url": "https://www.ministryofimage.net/product-page/fallout-equestria-project-horizons-part-5",
+				"title": "Hardcover (Volume 5)"
 			}
 		],
 		"tags": [
@@ -2356,7 +2364,7 @@
 	}
 		,{
 		"id": 80,
-		"title": "Fallout: Equestria",
+		"title": "Fallout: Equestria (AE)",
 		"edition": "4",
 		"img": "https://cdn-img.fimfiction.net/story/fuca-1432496101-119190-medium",
 		"rating": "M",
@@ -2374,12 +2382,16 @@
 				"title": "Fimfiction.net"
 			},
 			{
-				"url": "https://goo.gl/GZw21f",
-				"title": "Hardcover w/ Dust Cover, Reserve List"
+				"url": "https://absolutelyeverything.org/collections/fallout-equestria-books/products/fallout-equestria-4th-edition",
+				"title": "Hardcover w/ Dust Cover"
+			},
+			{
+				"url": "https://absolutelyeverything.org/collections/fallout-equestria-books/products/fallout-equestria-the-black-book-edition",
+				"title": "Black Book Edition"
 			}
 		],
 		"tags": [
-			"fimfic", "hardcover", "foe", "reserve"
+			"fimfic", "hardcover", "foe"
 		]
 	}
 	,{
@@ -2389,7 +2401,7 @@
 		"img": "https://cdn-img.fimfiction.net/story/rgi2-1432445486-47300-medium",
 		"rating": "M",
 		"dateAdded": "2019/02/14",
-		"expiry": "2019/03/24",
+		"expiry": null,
 		"authors":[
 			{
 				"name": "FuzzyVeeVee",
@@ -2402,12 +2414,12 @@
 				"title": "Fimfiction.net"
 			},
 			{
-				"url": "https://goo.gl/87Wnja",
-				"title": "Hardcover w/ Dust Cover, Reserve List"
+				"url": "https://absolutelyeverything.org/collections/fallout-equestria-books/products/fallout-equestria-murky-number-seven",
+				"title": "Hardcover w/ Dust Cover"
 			}
 		],
 		"tags": [
-			"fimfic", "hardcover", "foe", "reserve"
+			"fimfic", "hardcover", "foe"
 		]
 	}
 	,{
@@ -2430,7 +2442,7 @@
 				"title": "Fimfiction.net"
 			},
 			{
-				"url": "http://www.lulu.com/shop/anzel/secrets-of-a-royal-guard/hardcover/product-23980222.html",
+				"url": "https://www.lulu.com/shop/anzel/secrets-of-a-royal-guard/hardcover/product-23980222.html",
 				"title": "Hardcover w/ Dust Cover"
 			},
 			{
@@ -2504,7 +2516,7 @@
 	}
 	,{
 		"id": 87,
-		"title": "Stardust",
+		"title": "Stardust (Nonex Publ.)",
 		"edition": "2",
 		"img": "https://cdn-img.fimfiction.net/story/ddv4-1432482453-100455-medium",
 		"rating": "T",
@@ -2582,11 +2594,11 @@
 				"title": "Fimfiction.net"
 			},
 			{
-				"url": "http://www.lulu.com/shop/daedalus-aegle/the-education-of-clover-the-clever/hardcover/product-24093950.html",
+				"url": "https://www.lulu.com/shop/daedalus-aegle/the-education-of-clover-the-clever/hardcover/product-24093950.html",
 				"title": "Hardcover"
 			},
 			{
-				"url": "http://www.lulu.com/shop/daedalus-aegle/the-education-of-clover-the-clever-pb/paperback/product-24093939.html",
+				"url": "https://www.lulu.com/shop/daedalus-aegle/the-education-of-clover-the-clever-pb/paperback/product-24093939.html",
 				"title": "Paperback"
 			}
 		],
@@ -2609,7 +2621,7 @@
 			},
 			{
 				"name": "Ashton Crimson",
-				"url": "http://www.lulu.com/shop/search.ep?contributorId=1452280"
+				"url": "https://www.lulu.com/search?contributor=Ashton+Crimson"
 			}
 		],
 		"links": [
@@ -2618,7 +2630,7 @@
 				"title": "Fimfiction.net"
 			},
 			{
-				"url": "http://www.lulu.com/shop/ashton-crimson/before-time-began-to-flow/paperback/product-24082567.html",
+				"url": "https://www.lulu.com/shop/ashton-crimson/before-time-began-to-flow/paperback/product-24082567.html",
 				"title": "Paperback"
 			}
 		],
@@ -2628,7 +2640,7 @@
 	}
 	,{
 		"id": 92,
-		"title": "Stardust",
+		"title": "Stardust (MoI)",
 		"edition": "1",
 		"img": "https://cdn-img.fimfiction.net/story/ddv4-1432482453-100455-medium",
 		"rating": "T",
@@ -2702,7 +2714,7 @@
 				"title": "Fimfiction.net"
 			},
 			{
-				"url": "http://www.lulu.com/shop/gapjaxie/around-the-world-in-81-days/paperback/product-24199644.html",
+				"url": "https://www.lulu.com/shop/gapjaxie/around-the-world-in-81-days/paperback/product-24199644.html",
 				"title": "Paperback"
 			}
 		],
@@ -2759,11 +2771,11 @@
 			},
 			{
 				"url": "https://www.e-junkie.com/i/yjmi?card",
-				"title": "Perfect-Bound Paperback (US/Can/Mex)"
+				"title": "Paperback (US/Can/Mex)"
 			},
 			{
 				"url": "https://www.e-junkie.com/i/yjmh?card",
-				"title": "Perfect-Bound Paperback (International)"
+				"title": "Paperback (International)"
 			}
 		],
 		"tags": [
@@ -2790,11 +2802,11 @@
 				"title": "Fimfiction.net"
 			},
 			{
-				"url": "http://www.lulu.com/shop/saddlesoap-opera/history-repeats-paperback/paperback/product-24172657.html",
+				"url": "https://www.lulu.com/shop/saddlesoap-opera/history-repeats-paperback/paperback/product-24172657.html",
 				"title": "Paperback"
 			},
 			{
-				"url": "http://www.lulu.com/shop/saddlesoap-opera/history-repeats/hardcover/product-24353064.html",
+				"url": "https://www.lulu.com/shop/saddlesoap-opera/history-repeats/hardcover/product-24353064.html",
 				"title": "Hardcover"
 			}
 		],
@@ -2822,11 +2834,11 @@
 				"title": "Fimfiction.net"
 			},
 			{
-				"url": "http://www.lulu.com/shop/captain-chryssalid/the-best-night-ever-paperback/paperback/product-24172683.html",
+				"url": "https://www.lulu.com/shop/captain-chryssalid/the-best-night-ever-paperback/paperback/product-24172683.html",
 				"title": "Paperback"
 			},
 			{
-				"url": "http://www.lulu.com/shop/captain-chryssalid/the-best-night-ever/hardcover/product-24172670.html",
+				"url": "https://www.lulu.com/shop/captain-chryssalid/the-best-night-ever/hardcover/product-24172670.html",
 				"title": "Hardcover"
 			}
 		],
@@ -2854,27 +2866,27 @@
 				"title": "Fimfiction.net"
 			},
 			{
-				"url": "http://www.lulu.com/shop/cynewulf/the-night-is-passing-vol-i-paperback/paperback/product-24172473.html",
+				"url": "https://www.lulu.com/shop/cynewulf/the-night-is-passing-vol-i-paperback/paperback/product-24172473.html",
 				"title": "Paperback - Volume 1"
 			},
 			{
-				"url": "http://www.lulu.com/shop/cynewulf/the-night-is-passing-vol-ii-paperback/paperback/product-24172462.html",
+				"url": "https://www.lulu.com/shop/cynewulf/the-night-is-passing-vol-ii-paperback/paperback/product-24172462.html",
 				"title": "Paperback - Volume 2"
 			},
 			{
-				"url": "http://www.lulu.com/shop/cynewulf/the-night-is-passing-vol-iii-paperback/paperback/product-24172459.html",
+				"url": "https://www.lulu.com/shop/cynewulf/the-night-is-passing-vol-iii-paperback/paperback/product-24172459.html",
 				"title": "Paperback - Volume 3"
 			},
 			{
-				"url": "http://www.lulu.com/shop/cynewulf/the-night-is-passing-vol-i/hardcover/product-24352930.html",
+				"url": "https://www.lulu.com/shop/cynewulf/the-night-is-passing-vol-i/hardcover/product-24352930.html",
 				"title": "Hardcover - Volume 1"
 			},
 			{
-				"url": "http://www.lulu.com/shop/cynewulf/the-night-is-passing-vol-ii/hardcover/product-24352909.html",
+				"url": "https://www.lulu.com/shop/cynewulf/the-night-is-passing-vol-ii/hardcover/product-24352909.html",
 				"title": "Hardcover - Volume 2"
 			},
 			{
-				"url": "http://www.lulu.com/shop/cynewulf/the-night-is-passing-vol-iii/hardcover/product-24352894.html",
+				"url": "https://www.lulu.com/shop/cynewulf/the-night-is-passing-vol-iii/hardcover/product-24352894.html",
 				"title": "Hardcover - Volume 3"
 			}
 		],
@@ -2902,7 +2914,7 @@
 				"title": "Fimfiction.net"
 			},
 			{
-				"url": "http://www.lulu.com/shop/chris/the-purloined-pony-pick-your-path-12/paperback/product-24249799.html",
+				"url": "https://www.lulu.com/shop/chris/the-purloined-pony-pick-your-path-12/paperback/product-24249799.html",
 				"title": "Paperback"
 			}
 		],
@@ -2930,11 +2942,11 @@
 				"title": "Fimfiction.net"
 			},
 			{
-				"url": "http://www.lulu.com/shop/bookplayer/lost-time-paperback/paperback/product-24200739.html",
+				"url": "https://www.lulu.com/shop/bookplayer/lost-time-paperback/paperback/product-24200739.html",
 				"title": "Paperback"
 			},
 			{
-				"url": "http://www.lulu.com/shop/bookplayer/lost-time/hardcover/product-24353096.html",
+				"url": "https://www.lulu.com/shop/bookplayer/lost-time/hardcover/product-24353096.html",
 				"title": "Hardcover"
 			}
 		],
@@ -2962,7 +2974,7 @@
 				"title": "Fimfiction.net"
 			},
 			{
-				"url": "http://www.lulu.com/shop/admiral-biscuit/the-haunting/paperback/product-24168831.html",
+				"url": "https://www.lulu.com/shop/admiral-biscuit/the-haunting/paperback/product-24168831.html",
 				"title": "Paperback"
 			}
 		],
@@ -2990,7 +3002,7 @@
 				"title": "Fimfiction.net"
 			},
 			{
-				"url": "http://www.lulu.com/shop/bronywriter/td-the-alicorn-princess/paperback/product-23795746.html",
+				"url": "https://www.lulu.com/shop/bronywriter/td-the-alicorn-princess/paperback/product-23795746.html",
 				"title": "Paperback"
 			}
 		],
@@ -3018,11 +3030,11 @@
 				"title": "Fimfiction.net"
 			},
 			{
-				"url": "http://www.lulu.com/content/paperback-book/into-the-dark/24918047",
+				"url": "https://www.lulu.com/content/paperback-book/into-the-dark/24918047",
 				"title": "Paperback"
 			},
 			{
-				"url": "http://www.lulu.com/content/hardcover-book/into-the-dark/24831764",
+				"url": "https://www.lulu.com/content/hardcover-book/into-the-dark/24831764",
 				"title": "Hardcover"
 			}
 		],
@@ -3050,11 +3062,11 @@
 				"title": "Fimfiction.net"
 			},
 			{
-				"url": "http://www.lulu.com/shop/flutterpriest/dash-tries-to-win-your-heart/paperback/product-24145890.html",
+				"url": "https://www.lulu.com/shop/flutterpriest/dash-tries-to-win-your-heart/paperback/product-24145890.html",
 				"title": "Paperback"
 			},
 			{
-				"url": "http://www.lulu.com/shop/flutterpriest/dash-tries-to-win-your-heart-hard-cover/hardcover/product-24168738.html",
+				"url": "https://www.lulu.com/shop/flutterpriest/dash-tries-to-win-your-heart-hard-cover/hardcover/product-24168738.html",
 				"title": "Hardcover"
 			}
 		],
@@ -3082,7 +3094,7 @@
 				"title": "Fimfiction.net"
 			},
 			{
-				"url": "http://www.lulu.com/shop/lynn-wahl/travelingtutor2em/paperback/product-24120528.html",
+				"url": "https://www.lulu.com/shop/lynn-wahl/travelingtutor2em/paperback/product-24120528.html",
 				"title": "Paperback"
 			}
 		],
@@ -3110,11 +3122,11 @@
 				"title": "Fimfiction.net"
 			},
 			{
-				"url": "http://www.lulu.com/shop/lynn-wahl/bcb-monster2cpb/paperback/product-24141158.html",
+				"url": "https://www.lulu.com/shop/lynn-wahl/bcb-monster2cpb/paperback/product-24141158.html",
 				"title": "Paperback"
 			},
 			{
-				"url": "http://www.lulu.com/shop/lynn-wahl/bcb-monster-2c/hardcover/product-24141128.html",
+				"url": "https://www.lulu.com/shop/lynn-wahl/bcb-monster-2c/hardcover/product-24141128.html",
 				"title": "Hardcover"
 			}
 		],
@@ -3142,11 +3154,11 @@
 				"title": "Fimfiction.net"
 			},
 			{
-				"url": "http://www.lulu.com/shop/lynn-wahl/bcb-letters2c-stdpaperback/paperback/product-24141167.html",
+				"url": "https://www.lulu.com/shop/lynn-wahl/bcb-letters2c-stdpaperback/paperback/product-24141167.html",
 				"title": "Paperback"
 			},
 			{
-				"url": "http://www.lulu.com/shop/lynn-wahl/bcb-letters-2c/hardcover/product-24140933.html",
+				"url": "https://www.lulu.com/shop/lynn-wahl/bcb-letters-2c/hardcover/product-24140933.html",
 				"title": "Hardcover"
 			}
 		],
@@ -3202,7 +3214,7 @@
 				"title": "Fimfiction.net"
 			},
 			{
-				"url": "http://www.lulu.com/shop/jetfire2012/its-a-dangerous-business-going-out-your-door/paperback/product-24225905.html",
+				"url": "https://www.lulu.com/shop/jetfire2012/its-a-dangerous-business-going-out-your-door/paperback/product-24225905.html",
 				"title": "Paperback"
 			}
 		],
@@ -3230,11 +3242,11 @@
 				"title": "Fimfiction.net"
 			},
 			{
-				"url": "http://www.lulu.com/shop/jeremy-p-courville/bulletproof-heart/paperback/product-24157826.html",
+				"url": "https://www.lulu.com/shop/jeremy-p-courville/bulletproof-heart/paperback/product-24157826.html",
 				"title": "Paperback"
 			},
 			{
-				"url": "http://www.lulu.com/shop/jeremy-p-courville/bulletproof-heart-hardcover/hardcover/product-24170071.html",
+				"url": "https://www.lulu.com/shop/jeremy-p-courville/bulletproof-heart-hardcover/hardcover/product-24170071.html",
 				"title": "Hardcover"
 			}
 		],
@@ -3262,7 +3274,7 @@
 				"title": "Fimfiction.net"
 			},
 			{
-				"url": "http://www.lulu.com/shop/jeremy-p-courville/the-gentle-nights-audience-of-one/paperback/product-24170075.html",
+				"url": "https://www.lulu.com/shop/jeremy-p-courville/the-gentle-nights-audience-of-one/paperback/product-24170075.html",
 				"title": "Paperback"
 			}
 		],
@@ -3290,7 +3302,7 @@
 				"title": "Fimfiction.net"
 			},
 			{
-				"url": "http://www.lulu.com/shop/phoenix/a-new-way/hardcover/product-24259465.html",
+				"url": "https://www.lulu.com/shop/phoenix/a-new-way/hardcover/product-24259465.html",
 				"title": "Hardcover"
 			}
 		],
@@ -3318,7 +3330,7 @@
 				"title": "Fimfiction.net"
 			},
 			{
-				"url": "http://www.lulu.com/shop/phoenix/fragments/hardcover/product-24259457.html",
+				"url": "https://www.lulu.com/shop/phoenix/fragments/hardcover/product-24259457.html",
 				"title": "Hardcover"
 			}
 		],
@@ -3346,7 +3358,7 @@
 				"title": "Fimfiction.net"
 			},
 			{
-				"url": "http://www.lulu.com/shop/phoenix/without-a-hive/hardcover/product-24144714.html",
+				"url": "https://www.lulu.com/shop/phoenix/without-a-hive/hardcover/product-24144714.html",
 				"title": "Hardcover"
 			}
 		],
@@ -3358,7 +3370,7 @@
 		"id": 116,
 		"title": "Knights of Equestria",
 		"edition": "1",
-		"img": "http://static.lulu.com/browse/product_thumbnail.php?productId=23020397&resolution=320",
+		"img": "https://assets.lulu.com/cover_thumbs/1/r/1r89rzej-front-shortedge-384.jpg",
 		"rating": "M",
 		"dateAdded": "2020/02/25",
 		"expiry": null,
@@ -3374,7 +3386,7 @@
 				"title": "DeviantArt"
 			},
 			{
-				"url": "http://www.lulu.com/shop/solaris90/knights-of-equestria/hardcover/product-23020397.html",
+				"url": "https://www.lulu.com/shop/solaris90/knights-of-equestria/hardcover/product-23020397.html",
 				"title": "Hardcover"
 			}
 		],
@@ -3402,7 +3414,7 @@
 				"title": "Fimfiction.net"
 			},
 			{
-				"url": "http://www.lulu.com/shop/tangerine-blast/spark-visions-of-twilight/paperback/product-24200783.html",
+				"url": "https://www.lulu.com/shop/tangerine-blast/spark-visions-of-twilight/paperback/product-24200783.html",
 				"title": "Paperback"
 			}
 		],
@@ -3430,7 +3442,7 @@
 				"title": "Fimfiction.net"
 			},
 			{
-				"url": "http://www.lulu.com/shop/wanderer-d/gunsmoke/paperback/product-24180275.html",
+				"url": "https://www.lulu.com/shop/wanderer-d/gunsmoke/paperback/product-24180275.html",
 				"title": "Paperback"
 			}
 		],
@@ -3458,7 +3470,7 @@
 				"title": "Fimfiction.net"
 			},
 			{
-				"url": "http://www.lulu.com/shop/the-24th-pegasus/a-song-of-storms-of-skies-long-forgotten/paperback/product-24151926.html",
+				"url": "https://www.lulu.com/shop/the-24th-pegasus/a-song-of-storms-of-skies-long-forgotten/paperback/product-24151926.html",
 				"title": "Paperback"
 			}
 		],
@@ -3486,20 +3498,20 @@
 				"title": "Fimfiction.net"
 			},
 			{
-				"url": "http://www.lulu.com/shop/phoenix/fallout-equestria-the-chrysalis-book-1-wake/hardcover/product-24431412.html",
+				"url": "https://www.lulu.com/shop/phoenix/fallout-equestria-the-chrysalis-book-1-wake/hardcover/product-24431412.html",
 				"title": "Hardcover (Volume 1)"
 			},
 			{
-				"url": "http://www.lulu.com/shop/phoenix/fallout-equestria-the-chrysalis-book-2-seek/hardcover/product-24431416.html",
+				"url": "https://www.lulu.com/shop/phoenix/fallout-equestria-the-chrysalis-book-2-seek/hardcover/product-24431416.html",
 				"title": "Hardcover (Volume 2)"
 			},
 			{
-				"url": "http://www.lulu.com/shop/phoenix/fallout-equestria-the-chrysalis-book-3-change/hardcover/product-24431417.html",
+				"url": "https://www.lulu.com/shop/phoenix/fallout-equestria-the-chrysalis-book-3-change/hardcover/product-24431417.html",
 				"title": "Hardcover (Volume 3)"
 			}
 		],
 		"tags": [
-			"hardcover", "fimfic"
+			"hardcover", "fimfic", "foe"
 		]
 	}
 	,{
@@ -3528,6 +3540,118 @@
 		],
 		"tags": [
 			"hardcover", "fimfic", "limited run"
+		]
+	}
+	,{
+		"id": 122,
+		"title": "My Little Sweetheart 7: Final",
+		"edition": "?",
+		"img": "https://assets.lulu.com/cover_thumbs/1/8/189j6vr9-front-shortedge-384.jpg",
+		"rating": "M",
+		"dateAdded": "2020/11/27",
+		"expiry": null,
+		"authors":[
+			{
+				"name": "Iris Trismegistus",
+				"url": "https://www.lulu.com/shop/search.ep?contributorId=1299801"
+			}
+		],
+		"links": [
+			{
+				"url": "https://www.lulu.com/shop/iris-trismegistus/my-little-sweetheart-7-final/paperback/product-189j6vr9.html",
+				"title": "Paperback"
+			}
+		],
+		"tags": [
+			"paperback", "on demand", "art"
+		]
+	}
+	,{
+		"id": 123,
+		"title": "Fallout Equestria: Duck and Cover (& Make Love Not War)",
+		"edition": "1",
+		"img": "https://cdn-img.fimfiction.net/story/ur3l-1432512535-141568-medium",
+		"rating": "M",
+		"dateAdded": "2020/11/27",
+		"expiry": null,
+		"authors":[
+			{
+				"name": "hahatimeforponies",
+				"url": "https://www.fimfiction.net/user/4287/hahatimeforponies"
+			}
+		],
+		"links": [
+			{
+				"url": "https://www.fimfiction.net/story/141568/fallout-equestria-duck-and-cover",
+				"title": "Duck and Cover (Fimfiction.net)"
+			},
+			{
+				"url": "https://www.fimfiction.net/story/301900/fallout-equestria-make-love-not-war",
+				"title": "Make Love Not War (Fimfiction.net)"
+			},
+			{
+				"url": "https://absolutelyeverything.org/collections/fallout-equestria-books/products/fallout-equestria-duck-and-cover",
+				"title": "Hardcover w/ Dust Cover"
+			}
+		],
+		"tags": [
+			"fimfic", "hardcover", "foe", "Make Love Not War"
+		]
+	}
+	,{
+		"id": 124,
+		"title": "Fallout: Equestria (MoI)",
+		"edition": "1",
+		"img": "https://cdn-img.fimfiction.net/story/fuca-1432496101-119190-medium",
+		"rating": "M",
+		"dateAdded": "2020/11/27",
+		"expiry": null,
+		"authors":[
+			{
+				"name": "Kkat",
+				"url": "https://www.fimfiction.net/user/10369/Kkat"
+			}
+		],
+		"links": [
+			{
+				"url": "https://www.fimfiction.net/story/119190/fallout-equestria",
+				"title": "Fimfiction.net"
+			},
+			{
+				"url": "https://www.ministryofimage.net/product-page/fallout-equestria",
+				"title": "Hardcover"
+			}
+		],
+		"tags": [
+			"hardcover", "fimfic", "foe"
+		]
+	}
+	,{
+		"id": 125,
+		"title": "The Enchanted Library",
+		"edition": "1",
+		"img": "https://cdn-img.fimfiction.net/story/rkmy-1593759272-240255-medium",
+		"rating": "T",
+		"dateAdded": "2020/11/27",
+		"expiry": null,
+		"authors":[
+			{
+				"name": "Monochromatic",
+				"url": "https://www.fimfiction.net/user/121767/Monochromatic"
+			}
+		],
+		"links": [
+			{
+				"url": "https://www.fimfiction.net/story/240255/the-enchanted-library",
+				"title": "Fimfiction.net"
+			},
+			{
+				"url": "https://www.ministryofimage.net/product-page/the-enchanted-library",
+				"title": "Hardcover (Preorder)"
+			}
+		],
+		"tags": [
+			"hardcover", "fimfic"
 		]
 	}
 ]


### PR DESCRIPTION
Added
 - My Little Sweetheart 7
 - Fallout Equestria: Duck and Cover (& Make Love Not War)
 - Fallout Equestria: Project Horizons (pt. 4 & 5)
 - Fallout: Equestria (MoI edition)
 - The Enchanted Library

Changed
 - Fallout: Equestria 4th Edition + Black Book Edition (now on AE's store)
 - Fallout Equestria: Murky Number 7 (now on AE's store)
 - Fallout Equestria: Project Horizons (Still available on MoI)

Fixed images on
 - Background Pony
 - Daring Do Adventures #1: Daring Do and the Quest for the Sapphire Stone
 - Mlp Comic
 - My Little Sweetheart
 - My Little Sweetheart Too!
 - My Little Sweetheart 3
 - My Little Sweetheart 4
 - My Little Sweetheart 5
 - Rainbow Light and Friends - a Coloring Book
 - The Hope Called Night: Firstborn
 - Torchwood: The New Equestria Files

Removed
 - Cutey Confidential 2015 - Standard Edition (no longer available)
 - Cutey Confidential 2015 - Premium Edition (no longer available)
 - Mi álbum (no longer available)
 - My Little Pony: Revenge of the Villains (no longer available)
 - All iisaw books (was doxxed and books were hit :( )

Replaced a bunch of http links with https
Replaced all "Perfect-bound paperback" with just "Paperback"
Differentiated between different printings in the title
Changed some links to Lulu authors
Some other misc things probably

♥